### PR TITLE
merge semantic segmentation dependencies

### DIFF
--- a/src/operator/batch_norm-inl.h
+++ b/src/operator/batch_norm-inl.h
@@ -41,7 +41,7 @@ struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
     .describe("Momentum for moving average");
     DMLC_DECLARE_FIELD(fix_gamma).set_default(true)
     .describe("Fix gamma while training");
-    DMLC_DECLARE_FIELD(fix_linear_trans).set_default(true)
+    DMLC_DECLARE_FIELD(fix_linear_trans).set_default(false)
     .describe("Fix linear transformation while training");
     DMLC_DECLARE_FIELD(use_global_stats).set_default(false)
     .describe("Whether use global moving statistics instead of local batch-norm. "


### PR DESCRIPTION
Add a parameter switch to better control batch normalization.  This is useful when training very deep networks like resnet101