### PR TITLE
fix correlation1D illegal cuda memory bug

### DIFF
--- a/src/operator/correlation1D.cu
+++ b/src/operator/correlation1D.cu
@@ -290,7 +290,7 @@ void Forward_gpu(
      
     int x_shift = - neighborhood_grid_radius_;
     if(single_side == -1) { // to the left
-      x_shift = -neighborhood_grid_width_;
+      x_shift = -neighborhood_grid_radius_;
     } else if(single_side == 1) { // to the right
       x_shift = 0;
     }
@@ -338,7 +338,7 @@ void Backward_gpu(
     
     int x_shift = - neighborhood_grid_radius_;
     if (single_side == -1) { // to the left
-      x_shift = -neighborhood_grid_width_;
+      x_shift = -neighborhood_grid_radius_;
     } else if(single_side == 1) { // to the right
       x_shift = 0;
     }


### PR DESCRIPTION
## Description ##
fix illegal cuda memory bug in correlation1D operator 
It's one old version left in master branch which index is calculated by mistake. Now it's updated.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)

